### PR TITLE
Fixed dependencies version for halla 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,12 @@
 - [***ATTENTION***](#attention)
 - [***Previous Version***](#previous-version)
 - [HAllA version # 0.8.20](#halla-version--0820)
+  - [Requirements](#requirements)
   - [Installation](#installation)
       - [Option 1. (Recommended):](#option-1-recommended)
-      - [Option 2. Install with `setup.py`](#option-2-install-with-setuppy)
-  - [HAllA Overview](#halla-overview)
-    - [Available parameters](#available-parameters)
-    - [1. Pairwise similarity matrix computation](#1-pairwise-similarity-matrix-computation)
-    - [2. Hierarchical clustering](#2-hierarchical-clustering)
-    - [3. Finding densely-associated blocks](#3-finding-densely-associated-blocks)
+- [for MacOS - read the notes on installing rpy2:](#for-macos---read-the-notes-on-installing-rpy2)
+- [specifically run 'env CC=/usr/local/Cellar/gcc/X.x.x/bin/gcc-X pip install rpy2'](#specifically-run-env-ccusrlocalcellargccxxxbingcc-x-pip-install-rpy2)
+- [where X.x.x is the gcc version on the machine **BEFORE** running the following command](#where-xxx-is-the-gcc-version-on-the-machine-before-running-the-following-command)
   - [Contributions](#contributions)
 
 # ***ATTENTION***
@@ -32,11 +30,26 @@ Given two high-dimensional 'omics datasets X and Y (continuous and/or categorica
 
 Example codes can be found under `examples` directory.
 
+## Requirements
+- Python>=3.8
+- R  
+
 ## Installation
 #### Option 1. (Recommended):
 ```
-pip install halla --no-binary :all:
+pip install halla 
 ```
+
+**Note**: Please install the following `R packages` manually:
+- [eva](https://cran.r-project.org/web/packages/eva/index.html) (>= 0.2.6)
+  ```
+  install.packages("eva")
+  ```
+- [XICOR](https://cran.r-project.org/web/packages/XICOR/index.html) (>= 0.3.3)
+  ```
+  install.packages("XICOR")
+  ```
+
 #### Option 2. Install with `setup.py`
 ```
 python setup.py develop
@@ -44,9 +57,10 @@ python setup.py develop
 
 Other than [Python](https://www.python.org/) (version >= 3.7) and [R](https://www.r-project.org/) (version >= 3.6.1), install all required libraries listed in `requirements.txt`, specifically:
 
+
 Requirements Python packages:
 - [jenkspy](https://github.com/mthh/jenkspy) (version >= 0.1.5)
-- [Matplotlib](https://matplotlib.org/) (version >= 3.3.0)
+- [Matplotlib](https://matplotlib.org/) (version >= 3.5.3)
 - [NumPy](https://numpy.org/) (version >= 1.19.0)
 - [pandas](https://pandas.pydata.org/) (version >= 1.0.5)
 - [PyYAML](https://pypi.org/project/PyYAML/) (version >= 5.4)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jenkspy>=0.1.5
-matplotlib>=3.3.0
+matplotlib==3.5.3
 numpy>=1.19.0
 pandas>=1.0.5
 PyYAML>=5.4
@@ -7,6 +7,6 @@ rpy2>=3.3.5
 scikit-learn>=0.23.1
 scipy>=1.5.1
 seaborn>=0.10.1
-sklearn>=0.0
-statsmodels>=0.11.1
+#sklearn>=0.0
+statsmodels==0.11.1
 tqdm>=4.50.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jenkspy>=0.1.5
-matplotlib==3.5.3
+matplotlib>=3.5.3
 numpy>=1.19.0
 pandas>=1.0.5
 PyYAML>=5.4
@@ -8,5 +8,5 @@ scikit-learn>=0.23.1
 scipy>=1.5.1
 seaborn>=0.10.1
 #sklearn>=0.0
-statsmodels==0.11.1
+statsmodels>=0.11.1
 tqdm>=4.50.2


### PR DESCRIPTION
Hi @ljmciver , 

I was looking at the halla installation issue pointed out by Jacob and Will and we were installing halla directly from source than wheel in PyPi which was taking a long installation time. 
`pip install halla --no-binary :all:`

Here, in this PR I have made the following changes: 
- Updated README to point users to just `pip install halla` rather than  `--no-binary :all:` flag + Added instructions for "eva" and "XICOR" R package installation 
- Tested the github install with `python3.8 setup.py develop` and made the needed dependency changes for the requirement package. (Everytime works well for github install)
    - Commented `sklearn>=0.0` in requirements.txt since it is deprecated and we are using  `scikit-learn>=0.23.1` 
    - Updated matplotlib version to `3.5.3`

Core Requirements to keep in mind:  (Please let me know if you think this is an issue)
```
- Python version >= 3.8
- R (eva and Xicor packages manual installation)
```

ToDo: 
- Release the halla github changes in PyPi and test the PyPi release for any issues. 

Can you take a look at this PR please and let me know if you see any red flags? I wanted to get in touch with you before release the changes to PyPi. 

Regards,
Sagun